### PR TITLE
Fixed typographical error, changed aquisition to acquisition in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 a spectral hash code
 
-this library is the current reference implementation for the splash. Splash stands for the spectra hash code and is an unique identifier independent of aquisition or processing. It basically tries to ensure that you can easily tell if two spectra are identical, similar or very different. Based on several criteria.
+this library is the current reference implementation for the splash. Splash stands for the spectra hash code and is an unique identifier independent of acquisition or processing. It basically tries to ensure that you can easily tell if two spectra are identical, similar or very different. Based on several criteria.
 
 You can access it as a REST service, at http://splash.fiehnlab.ucdavis.edu
 


### PR DESCRIPTION
@berlinguyinca, I've corrected a typographical error in the documentation of the [spectra-hash](https://github.com/berlinguyinca/spectra-hash) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.