### PR TITLE
C++ code cleanup

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -17,3 +17,6 @@ clean:
 test:
 	$(CC) $(CPPFLAGS) $(LDFLAGS) -o $(TARGET) -I src -o $(TARGET)_test src/$(TARGET).cpp tests/test_$(TARGET).cpp $(LDLIBS) && \
 	./$(TARGET)_test
+
+format:
+	clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, Standard: Cpp03}" -i src/splash*

--- a/cpp/src/splash.hpp
+++ b/cpp/src/splash.hpp
@@ -1,12 +1,12 @@
-#ifndef SPLASH_H    // To make sure you don't declare the function more than once by including the header multiple times.
+#ifndef SPLASH_H // To make sure you don't declare the function more than once
+                 // by including the header multiple times.
 #define SPLASH_H
 
 #include <string>
 #include <vector>
 
-using namespace std;
-
-string splashIt(vector<pair<double, double> > &spectrum, char spectrum_type);
-string splashIt(string spectrum_string, char spectrum_type);
+std::string splashIt(const std::vector<std::pair<double, double> > &spectrum,
+                     char spectrum_type);
+std::string splashIt(const std::string &spectrum_string, char spectrum_type);
 
 #endif

--- a/cpp/src/splashIt.cpp
+++ b/cpp/src/splashIt.cpp
@@ -5,46 +5,44 @@
 
 #include "splash.hpp"
 
-
 using namespace std;
-
 
 // Debug mode
 const bool DEBUG = false;
 
-
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
     int i = 0;
     string input;
-    
+
     // Log times
     clock_t start = clock();
-    
 
-    while(getline(cin, input)) {
+    while (getline(cin, input)) {
         ++i;
-        
-        if(DEBUG) {
+
+        if (DEBUG) {
             cerr << "Spectrum #" << i << endl;
         }
 
         // Handle input of the form [id],[spectrum string]
         size_t delim_pos = input.find(',');
 
-        if(delim_pos != string::npos) {
+        if (delim_pos != string::npos) {
             string id = input.substr(0, delim_pos);
             string spectrum_string = input.substr(delim_pos + 1);
 
             // Print the spectrum id with the calculated splash id and spectrum
-            cout << splashIt(spectrum_string, '1') << "," << id << "," << spectrum_string << endl;
+            cout << splashIt(spectrum_string, '1') << "," << id << ","
+                 << spectrum_string << endl;
         } else {
             // Print the calculated splash id and spectrum
             cout << splashIt(input, '1') << "," << input << endl;
         }
-        
+
         // Provide output for large files
-        if(i % 10000 == 0) {
-            cerr << "processed " << i << " spectra, " << setprecision(2) << fixed
+        if (i % 10000 == 0) {
+            cerr << "processed " << i << " spectra, " << setprecision(2)
+                 << fixed
                  << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) / i
                  << " ms average time to splash a spectrum." << endl;
         }
@@ -53,6 +51,8 @@ int main(int argc, char** argv) {
     cerr << "finished processing, processing took: " << setprecision(2) << fixed
          << (std::clock() - start) / (double)CLOCKS_PER_SEC << " s" << endl
          << "processed " << i << " spectra" << endl
-         << "average time including io to splash a spectrum is: " << setprecision(2) << fixed
-         << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) / i  << " ms" << endl;
+         << "average time including io to splash a spectrum is: "
+         << setprecision(2) << fixed
+         << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) / i
+         << " ms" << endl;
 }


### PR DESCRIPTION
Hello, I've put some quick fixes:

* Applied `clang-format` to the codebase (see extra `Makefile` target)
* Avoid using `new` (`histogram` apparently leaked memory)
* Don't modify input vector (`encodeSpectrum` copies input before sorting)
* Avoid cluttering global namespace in the header file
