### PR TITLE
Prevent generation of SPLASH codes for empty spectra in REST API

### DIFF
--- a/core/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/core/impl/SplashVersion1.java
+++ b/core/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/core/impl/SplashVersion1.java
@@ -184,13 +184,14 @@ public class SplashVersion1 implements Splash {
      * @return computed splash
      */
     public final String splashIt(Spectrum spectrum) {
+
         if (spectrum.getType() == SpectraType.MS) {
             for (Ion ion : spectrum.getIons()) {
                 if (ion.getIntensity() < 0) {
-                    throw new RuntimeException("ion's need to have an intensity larger than zero");
+                    throw new RuntimeException("ions need to have an intensity larger than zero");
                 }
                 if (ion.getMass() < 0) {
-                    throw new RuntimeException("ion's need to have an mass larger than zero");
+                    throw new RuntimeException("ions need to have an mass larger than zero");
                 }
             }
         }

--- a/core/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/core/types/Ion.java
+++ b/core/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/core/types/Ion.java
@@ -3,11 +3,13 @@ package edu.ucdavis.fiehnlab.spectra.hash.core.types;
 /**
  * defines a basic ion for a spectra key
  */
-public class Ion implements Comparable<Ion>{
+public class Ion implements Comparable<Ion> {
     private static String SEPERATOR = ":";
     private static int PRECESSION = 6;
 
     private Double mass;
+    private Double intensity;
+
 
     @Override
     public boolean equals(Object o) {
@@ -28,7 +30,7 @@ public class Ion implements Comparable<Ion>{
         return result;
     }
 
-    public Ion(){}
+    public Ion() {}
 
     public Ion(double mass, double intensity) {
         this.mass = mass;
@@ -51,9 +53,7 @@ public class Ion implements Comparable<Ion>{
         this.mass = mass;
     }
 
-    private Double intensity;
-
-    public String toString(){
+    public String toString() {
         return String.format("%."+PRECESSION+"f",this.getMass()) + SEPERATOR + String.format("%." + PRECESSION + "f", this.getIntensity());
     }
 

--- a/web/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/rest/RestController.java
+++ b/web/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/rest/RestController.java
@@ -38,10 +38,14 @@ public class RestController {
         try {
             logger.info("received spectrum: " + spectrum);
 
+            if (spectrum.getIons().isEmpty()) {
+                throw new RuntimeException("spectrum must have at least one ion");
+            }
+
             String hash = spectraHash.splashIt(spectrum);
             logger.info("generated hash: " + hash);
-            return hash;
 
+            return hash;
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
             throw new RuntimeException(e);

--- a/web/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/rest/RestController.java
+++ b/web/src/main/java/edu/ucdavis/fiehnlab/spectra/hash/rest/RestController.java
@@ -10,7 +10,6 @@ import edu.ucdavis.fiehnlab.spectra.hash.rest.dao.ValidationResponse;
 import org.apache.log4j.Logger;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 /**
@@ -31,9 +30,11 @@ public class RestController {
 
     /**
      * converts a spectra to the hash code
+     * @param spectrum
+     * @return splash code
      */
     @RequestMapping(value = "/splash/it", method = RequestMethod.POST)
-    public String convert(@RequestBody Spectrum spectrum) throws NoSuchAlgorithmException {
+    public String convert(@RequestBody Spectrum spectrum) {
 
         try {
             logger.info("received spectrum: " + spectrum);
@@ -64,9 +65,11 @@ public class RestController {
 
     /**
      * converts a spectra to the hash code
+     * @param validationRequest
+     * @return validation response
      */
     @RequestMapping(value = "/splash/validate", method = RequestMethod.POST)
-    public ValidationResponse validate(@RequestBody ValidationRequest validationRequest) throws NoSuchAlgorithmException {
+    public ValidationResponse validate(@RequestBody ValidationRequest validationRequest) {
 
         try {
             String reference = spectraHash.splashIt(validationRequest.getSpectrum());


### PR DESCRIPTION
Instead of returning a SPLASH:

`curl 'https://splash.fiehnlab.ucdavis.edu/splash/it' -H 'Content-type: application/json' -d'{"ions":[],"type":"MS"}'`

now returns an exception:
`{"timestamp":1582935244885,"status":500,"error":"Internal Server Error","exception":"java.lang.RuntimeException","message":"java.lang.RuntimeException: spectrum must have at least one ion","path":"/splash/it"}`