### PR TITLE
Fixed histogram binning issue in splashR

### DIFF
--- a/core/src/test/java/edu/ucdavis/fiehnlab/spectra/hash/core/impl/SplashVersion1Test.java
+++ b/core/src/test/java/edu/ucdavis/fiehnlab/spectra/hash/core/impl/SplashVersion1Test.java
@@ -410,4 +410,24 @@ public class SplashVersion1Test extends AbstractSpectraHashImplTester {
         }
     }
 
+    /**
+     * tests for the SPLASH histogram issue reported in:
+     * https://github.com/MassBank/MassBank-data/issues/248
+     */
+    @Test
+    public void testSplashItHistogramSmallIntensities() {
+
+        Splash splash = getHashImpl();
+
+        Spectrum spectrum = new SpectrumImpl(Arrays.asList(
+                new Ion(44.998, 0.2),
+                new Ion(80.0261, 0.1),
+                new Ion(93.0321, 0.4),
+                new Ion(108.0227, 0.3)
+
+        ), SpectraType.MS);
+
+        String hash = splash.splashIt(spectrum);
+        assertEquals(hash, "splash10-052f-9300000000-5cd70311703e2423a1c5");
+    }
 }

--- a/python/tests/test_splash.py
+++ b/python/tests/test_splash.py
@@ -25,5 +25,21 @@ class TestSplash(unittest.TestCase):
 
         self.assertEqual(Splash().splash(Spectrum(spectrum_string, SpectrumType.MS)), splash_code)
 
+    def test_small_intensities(self):
+        # tests for the initial SPLASH issue reported in:
+        # https://github.com/MassBank/MassBank-data/issues/248
+        spectrum_string = "44.998:0.2 80.0261:0.1 93.0321:0.4 108.0227:0.3"
+        splash_code = 'splash10-052f-9300000000-5cd70311703e2423a1c5'
+
+        self.assertEqual(Splash().splash(Spectrum(spectrum_string, SpectrumType.MS)), splash_code)
+
+        # using MassBank scaled intensities
+        # should yield the same histogram blocks but different hash block
+        spectrum_string = "44.998:499 80.0261:249 93.0321:999 108.0227:749"
+        splash_code = 'splash10-052f-9300000000-a485843aed0475c0a1b9'
+
+        self.assertEqual(Splash().splash(Spectrum(spectrum_string, SpectrumType.MS)), splash_code)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/splashR/R/getSplash.R
+++ b/splashR/R/getSplash.R
@@ -96,11 +96,10 @@ getBlockHist <- function(peaks, histBase, histLength, binSize) {
     summedintensities <- tapply(peaks[,2], binindex, sum)
     wrappedbinindex <- unique(binindex) %% histLength
     wrappedintensities <- tapply(summedintensities, wrappedbinindex, sum)
-    normalisedintensities <- as.integer(wrappedintensities/max(wrappedintensities)*(histBase-1))
+    normalisedintensities <- as.integer(EPS_CORRECTION + (histBase-1) * wrappedintensities / max(wrappedintensities))
     
     wrappedhist[sort(unique(wrappedbinindex))+1] <- normalisedintensities
     paste(integer2base36(wrappedhist), collapse="")
-  
 }
 
 getSplash <- function(peaks) {

--- a/splashR/tests/testthat/test-small-intensities.R
+++ b/splashR/tests/testthat/test-small-intensities.R
@@ -1,0 +1,16 @@
+library(splashR)
+context("Test suite")
+
+test_that("small-intensities", {
+  # tests for the SPLASH histogram issue reported in:
+  # https://github.com/MassBank/MassBank-data/issues/248
+  s <- cbind(mz=c(44.998, 80.0261, 93.0321, 108.0227),
+             intensity=c(0.2, 0.1, 0.4, 0.3))
+  expect_equal(getSplash(s), "splash10-052f-9300000000-5cd70311703e2423a1c5")
+
+  # using MassBank scaled intensities
+  # should yield the same histogram blocks but different hash block
+  s <- cbind(mz=c(44.998, 80.0261, 93.0321, 108.0227),
+             intensity=c(499, 249, 999, 749))
+  expect_equal(getSplash(s), "splash10-052f-9300000000-a485843aed0475c0a1b9")
+})


### PR DESCRIPTION
Fixes inconsistent histogram generation between the R and Java implementations reported in MassBank/MassBank-data#248.

In splashR, the epsilon correction factor was not applied before converting binned intensities to integers. Without the correction one of the bins was lost due to a floating point artifact in this particular spectrum. I'm surprised that error this did not come up in any of our test sets during validation.